### PR TITLE
Added status code 200 or 400 to httprequest processing

### DIFF
--- a/inc/HTTPRequest/HTTPRequest.hpp
+++ b/inc/HTTPRequest/HTTPRequest.hpp
@@ -7,7 +7,7 @@
 class HTTPParser;
 
 //TO-DO
-//	implement err as enum
+//	improve protocol parsing
 class HTTPRequest {
 	public:
 		HTTPRequest();
@@ -29,8 +29,8 @@ class HTTPRequest {
 		std::string		getBody() const { return _body; }
 		uint32_t		getPort() const { return _port; }
 		in_addr_t		getIPAddress() const { return _ip_address; }
-		//to be changed to enum
-		bool			success() const { return _processed; }
+		bool			success() const;
+		int				getStatusCode() const { return _statusCode; }
 
 		std::map<std::string, std::string>	&getQueryParams() { return _query; }
 		std::map<std::string, std::string>	&getAllParams() { return _params; }
@@ -60,11 +60,11 @@ class HTTPRequest {
 
 		HTTPParser							*parser;
 		std::string							_content;
+		int									_statusCode;
 
 		std::string 						_method;
 		std::string							_requestURI;
 		std::string 						_protocol;
-		std::map<std::string, std::string>	_accept;
 		std::map<std::string, std::string>	_query;
 		bool								_keepAlive;
 		int									_contentLength;
@@ -75,9 +75,6 @@ class HTTPRequest {
 
 		std::map<std::string, std::string>	_params;
 		bool								_parserCreated;
-		//to be changed to enum
-		bool								_processed;
-
 };
 
 #endif

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -81,9 +81,9 @@ int Client::parseHTTPRequest(std::string request_str) {
 	}
 	request->setPort(parent_server->getPort());
 	request->setIPAddress(parent_server->getIPAddress());
-	try {
-		request->process(request_str);
-	} catch (std::exception &e) {
+	request->process(request_str);
+	if (!request->success()) {
+		_status_code = 400;
 		return 1;
 	}
 	return 0;

--- a/src/HTTPRequest/HTTPRequest.cpp
+++ b/src/HTTPRequest/HTTPRequest.cpp
@@ -2,10 +2,10 @@
 
 
 HTTPRequest::HTTPRequest():
+	_statusCode(200),
 	_keepAlive(true),
 	_contentLength(0),
-	_parserCreated(false),
-	_processed(true) {
+	_parserCreated(false) {
 	_port = htons(8080);
 	_ip_address = inet_addr("0.0.0.0");
 }
@@ -15,14 +15,15 @@ void HTTPRequest::process(std::string request) {
 	try {
 		parse();
 		setup();
+		log(std::cout, SUCCESS, "HTTP Request successfully processed", "");
 	} catch (parserNotInitialized &e) {
+		_statusCode = 400;
 		log(std::cerr, ERROR, "HTTPRequest", e.what());
 	} catch(HTTPParser::invalidSyntaxException &e) {
 		log(std::cerr, ERROR, "Parser", e.what());
-		_processed = false;
+		_statusCode = 400;
 	} catch(invalidHTTPRequest &e) {
-		log(std::cerr, ERROR, "HTTPRequest", e.what());
-		_processed = false;
+		_statusCode = 400;
 	}
 }
 
@@ -67,7 +68,7 @@ void	HTTPRequest::parse(){
 		_parserCreated = true;
 		parser->parse();
 	} catch(HTTPLexer::emptyRequestException &e) {
-		log(std::cerr, ERROR, "Lexer", e.what());
+		log(std::cerr, ERROR, "HTTPLexer", e.what());
 		throw parserNotInitialized();
 	}
 }
@@ -124,10 +125,10 @@ void	HTTPRequest::setup() {
 
 					_params[paramName] = paramContent;
 				} else {
-					//change to exception
 					std::string err = "Invalid header: ";
 					err.append(paramName);
 					log(std::cout, ERROR, err, "");
+					throw invalidHTTPRequest();
 				}
 				break ;
 			}
@@ -143,9 +144,9 @@ void	HTTPRequest::setup() {
 
 void	HTTPRequest::checkIfConnection(std::string paramName, std::string paramContent) {
 	if (paramName == "connection") {
-		//change to print error or throw exception
 		if (paramContent != "keep-alive" && paramContent != "closed") {
 			log(std::cerr, ERROR, "Connection invalid param", paramContent);
+			throw invalidHTTPRequest();
 		}
 		_keepAlive = (paramContent == "keep-alive") ? true : false;
 	}
@@ -198,10 +199,10 @@ void	HTTPRequest::displayRequest() {
 }
 
 void HTTPRequest::displayParsedRequest(){
-	std::cout << std::left << std::setw(25) << "Host: " << std::setw(20) << _ip_address << ":" << ntohs(_port) << std::endl;
-	std::cout << std::left << std::setw(25) << "Method: " << std::setw(20) << _method << std::endl;
-	std::cout << std::left << std::setw(25) << "Request URI:" << std::setw(20) << _requestURI << std::endl;
-	std::cout << std::left << std::setw(25) << "Protocol:" << std::setw(20) << _protocol << std::endl;
+	std::cout << std::left << std::setw(25) << "Host: " << _ip_address << ":" << ntohs(_port) << std::endl;
+	std::cout << std::left << std::setw(25) << "Method: " << _method << std::endl;
+	std::cout << std::left << std::setw(25) << "Request URI:" << _requestURI << std::endl;
+	std::cout << std::left << std::setw(25) << "Protocol:" << _protocol << std::endl;
 	std::map<std::string, std::string>::iterator it;
 	
 	if (_query.size()) {
@@ -212,22 +213,9 @@ void HTTPRequest::displayParsedRequest(){
 			temp.append(":");
 			std::cout << std::left << std::setw(25) << temp << std::setw(20) << it->second << std::endl;
 		}
-		if (_accept.empty())
-			std::cout << std::endl;
 	}
 
-	if (_accept.size()) {
-		std::cout << "\n###Accept params###" << std::endl;
-		it = _accept.begin();
-		for (; it != _accept.end(); it++) {
-			std::string temp = it->first;
-			temp.append(":");
-			std::cout << std::left << std::setw(25) << temp << std::setw(20) << it->second << std::endl;
-		}
-		std::cout << std::endl;
-	}
-
-	std::cout << std::left << std::setw(25) << "keep-alive:" << 
+	std::cout << std::endl << std::left << std::setw(25) << "keep-alive:" << 
 		std::setw(20) << (_keepAlive ? "true" : "false")<< std::endl << std::endl;
 
 	std::cout << std::left << std::setw(25) << "content-length" << 
@@ -243,4 +231,8 @@ void HTTPRequest::displayParsedRequest(){
 	if (_body.size()) {
 		std::cout << "\r\n" << _body << std::endl;
 	}
+}
+
+bool	HTTPRequest::success() const {
+	return _statusCode < 400;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,8 @@ int main(int argc, char **argv) {
 		std::cout << "[ERROR]:\t\tUsage: ./webserv [config_file_path]" << std::endl;
 		return 1;
 	}
-
+	// TO-DO
+	// implement sighandler
 	try {
 		std::string content = readConfigurationFile(argc, argv);
 
@@ -38,9 +39,6 @@ int main(int argc, char **argv) {
 		std::cerr << e.what() << std::endl;
 		return 1;
 	}
-
-	// will delete later
-
 
 	return 0;
 }


### PR DESCRIPTION
Estive a ver melhor os códigos de erro e parece-me que do httprequest só pode vir o 400 de erro. Todos os outros códigos são vistos depois na altura de construir a resposta - isto é, são parâmetros que estão correctos em termos de sintaxe, mas o servidor decide que não os consegue processar.

Btw, temos de rever a questão do protocolo - não sei se não será melhor implementar dois ints, um de major version e outro de minor. Pelo menos é isso que esta no rfc e é muito mais flexível do que aquilo que temos agora implementado.